### PR TITLE
add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,6 @@
     "wistcc <wistcc@gmail.com> http://winnercrespo.com", 
     "vetom <tomasverasm@gmail.com>"
   ],
+  "repository": "https://github.com/wistcc/werewolf-brain",
   "license": "ISC"
 }


### PR DESCRIPTION
It's rather rare when there are no npm warnings, and this single warning (`no repository field`) is quite easy to fix