### PR TITLE
Using prepare instead of prepublish.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "webpack",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "mocha --compilers js:babel-core/register tests --recursive",
     "testw": "mocha --compilers js:babel-core/register tests --recursive -w"
   },


### PR DESCRIPTION
As of npm@5, `prepublish` scripts are deprecated. We should use `prepare` instead.